### PR TITLE
Add potential support for Killstreak Fabricators

### DIFF
--- a/index.js
+++ b/index.js
@@ -742,7 +742,8 @@ class ListingManager {
             defindex: item.defindex,
             quality: 6,
             killstreak: item.killstreak,
-            australium: item.australium
+            australium: item.australium,
+            target: item.target
         }, false);
 
         const formatted = {


### PR DESCRIPTION
This is done by passing item.target to schema.getName, which would make this: 'Specialized Killstreak Kit Fabricator' into this: 'Specialized Killstreak Medi Gun Kit fabricator'. This could add support for fabricators if backpack.tf ever fixes their API to allow this.